### PR TITLE
fixed markdown syntax of the images

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ You can define colors either by name "yellow" or by code "#FFFFFF" (white)
 
 **Horizontal Line**
 
-![Horizontal Line] (https://github.com/HectorMunoz/Line-Widgets/blob/master/Line_Widgets/HorizontalLine.png)
+![Horizontal Line](https://github.com/HectorMunoz/Line-Widgets/blob/master/Line_Widgets/HorizontalLine.png)
 
 
 **Vertical Line**
 
-![Vertical Line] (https://github.com/HectorMunoz/Line-Widgets/blob/master/Line_Widgets/VerticalLine.png)
+![Vertical Line](https://github.com/HectorMunoz/Line-Widgets/blob/master/Line_Widgets/VerticalLine.png)
 
 This is the result of my first attempment about widget, so maybe there are better ways to do it!
 


### PR DESCRIPTION
The Markdown syntax of the README.md has some errors. There is a space in the image. 